### PR TITLE
hotfix: humanities 중복 문제 해결

### DIFF
--- a/src/main/java/com/gist/graduation/requirment/domain/humanities/Humanities.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/humanities/Humanities.java
@@ -37,36 +37,37 @@ public class Humanities extends RequirementStatusBaseEntity {
 
     private void checkHUSMandatory(UserTakenCoursesList inputUserTakenCoursesList) {
         List<TakenCourse> husCoursesList = HumanitiesListParser.getHUSCoursesList();
-        List<TakenCourse> userTakneHUSCourses = inputUserTakenCoursesList.getTakenCourses().stream()
+        List<TakenCourse> userTakenHUSCourses = inputUserTakenCoursesList.getTakenCourses().stream()
                 .filter(husCoursesList::contains)
                 .collect(Collectors.toList());
-        userTakneHUSCourses.forEach(s -> s.setHumanitiesType(CourseType.HUS));
+        userTakenHUSCourses.forEach(s -> s.setHumanitiesType(CourseType.HUS));
 
 
-        int husMinimumCondition = 6 - getSumofCredits(userTakneHUSCourses);
+        int husMinimumCondition = 6 - getSumofCredits(userTakenHUSCourses);
         if (husMinimumCondition > 0) {
             addMessage(String.format("HUS 과목을 %d학점 더 들어야 합니다.", (husMinimumCondition)));
         }
 
         this.getUserTakenCoursesList().addAll(
-                userTakneHUSCourses
+                userTakenHUSCourses
         );
     }
 
     private void checkPPEMandatory(UserTakenCoursesList inputUserTakenCoursesList) {
         List<TakenCourse> PPECoursesList = HumanitiesListParser.getPPECoursesList();
-        List<TakenCourse> userTaknePPECourses = inputUserTakenCoursesList.getTakenCourses().stream()
+        List<TakenCourse> userTakenPPECourses = inputUserTakenCoursesList.getTakenCourses().stream()
                 .filter(PPECoursesList::contains)
                 .collect(Collectors.toList());
-        userTaknePPECourses.forEach(s -> s.setHumanitiesType(CourseType.PPE));
+        userTakenPPECourses.forEach(s -> s.setHumanitiesType(CourseType.PPE));
 
-        int ppeMinimumCondition = 6 - getSumofCredits(userTaknePPECourses);
+        int ppeMinimumCondition = 6 - getSumofCredits(userTakenPPECourses);
         if (ppeMinimumCondition > 0) {
             addMessage(String.format("PPE 과목을 %d학점 더 들어야 합니다.", (ppeMinimumCondition)));
         }
+        System.out.println(userTakenPPECourses);
 
         this.getUserTakenCoursesList().addAll(
-                userTaknePPECourses
+                userTakenPPECourses
         );
     }
 

--- a/src/main/java/com/gist/graduation/requirment/presentation/TestController.java
+++ b/src/main/java/com/gist/graduation/requirment/presentation/TestController.java
@@ -4,7 +4,9 @@ import com.gist.graduation.requirment.application.GraduationRequirementStatusSer
 import com.gist.graduation.requirment.domain.GraduationRequirementStatus;
 import com.gist.graduation.requirment.domain.major.MajorType;
 import com.gist.graduation.requirment.dto.GradeToCheckRequest;
+import com.gist.graduation.user.taken_course.TakenCourse;
 import com.gist.graduation.user.taken_course.UserTakenCoursesList;
+import com.gist.graduation.utils.HumanitiesListParser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
@@ -13,8 +15,11 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @Profile("local")
@@ -24,7 +29,7 @@ public class TestController {
     private final GraduationRequirementStatusService graduationRequirementStatusService;
 
     @GetMapping("/upload")
-    public String formTest(@ModelAttribute GradeToCheckRequest request){
+    public String formTest(@ModelAttribute GradeToCheckRequest request) {
         return "upload";
     }
 
@@ -41,5 +46,15 @@ public class TestController {
         graduationRequirementStatus.checkGraduationRequirements(20, new UserTakenCoursesList(), MajorType.EC);
         model.addAttribute("result", graduationRequirementStatus);
         return "result";
+    }
+
+    @GetMapping("/humanities")
+    @ResponseBody
+    public List<TakenCourse> getHumanities() {
+        List<TakenCourse> ppeCoursesList = HumanitiesListParser.getPPECoursesList();
+        List<TakenCourse> husCoursesList = HumanitiesListParser.getHUSCoursesList();
+        List<TakenCourse> collect = ppeCoursesList.stream().filter(husCoursesList::contains).sorted((a, b) -> b.getCourseName().compareTo(a.getCourseName())).collect(Collectors.toList());
+        System.out.println(collect.size());
+        return collect;
     }
 }

--- a/src/main/java/com/gist/graduation/utils/CourseListParser.java
+++ b/src/main/java/com/gist/graduation/utils/CourseListParser.java
@@ -29,7 +29,7 @@ public class CourseListParser {
     public static File file;
 
     static {
-        ClassPathResource undergraduateResource = new ClassPathResource("/course-information/course_information_undergraduate.xls");
+        ClassPathResource undergraduateResource = new ClassPathResource("/course-information/course_information_undergraduate_from2018.xls");
         try {
             InputStream inputStream = undergraduateResource.getInputStream();
             file = File.createTempFile(UUID.randomUUID().toString(), ".xlsx");

--- a/src/main/java/com/gist/graduation/utils/HumanitiesListParser.java
+++ b/src/main/java/com/gist/graduation/utils/HumanitiesListParser.java
@@ -16,7 +16,7 @@ public class HumanitiesListParser {
 
     public static List<TakenCourse> getHUSCoursesList() {
         List<TakenCourse> HUSCoursesList = getHumanitiesCoursesList().stream()
-                .filter(s -> HUS_COURSE_CODE_LIST.stream().anyMatch(t -> s.getCourseCode().contains(t.toString())))
+                .filter(s -> HUS_COURSE_CODE_LIST.stream().anyMatch(t -> s.getCourseCode().charAt(0) == t.toString().charAt(0) && s.getCourseCode().charAt(1) == t.toString().charAt(1)))
                 .collect(Collectors.toList());
 
         HumanitiesExceptionConstants.HUSAmbiguousHumanities.removeNotHUS(HUSCoursesList);
@@ -25,9 +25,8 @@ public class HumanitiesListParser {
 
     public static List<TakenCourse> getPPECoursesList() {
         List<TakenCourse> PPECoursesList = getHumanitiesCoursesList().stream()
-                .filter(s -> PPE_COURSE_CODE_LIST.stream().anyMatch(t -> s.getCourseCode().contains(t.toString())))
+                .filter(s -> PPE_COURSE_CODE_LIST.stream().anyMatch(t -> s.getCourseCode().charAt(0) == t.toString().charAt(0) && s.getCourseCode().charAt(1) == t.toString().charAt(1)))
                 .collect(Collectors.toList());
-
         HumanitiesExceptionConstants.PPEAmbiguousHumanities.removeNotPPE(PPECoursesList);
         return PPECoursesList;
     }
@@ -63,6 +62,4 @@ public class HumanitiesListParser {
             }
         }
     }
-
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ swagger:
 
 
 request:
-  origins: http://localhost:3000,https://dev.gijol.im
+  origins: http://localhost:3000,http://localhost:3001,https://dev.gijol.im
 
 
 ---


### PR DESCRIPTION
humanities가 HUS PPE 중복으로 판별되는 문제를 해결했습니다. 이는 java의 contains를 활용해서 나온 문제였습니다. 첫 번째와 두 번째 문자열을 비교하려고 contains를 사용하다 다른 인덱스에서 contain되는 경우가 발생해 중복이 생겼습니다.