### PR TITLE
hotfix: 환경과와 기계과 전공필수 변경

### DIFF
--- a/src/main/java/com/gist/graduation/requirment/domain/major/EnvironmentMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/EnvironmentMajor.java
@@ -12,9 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum EnvironmentMajor {
 
-    FROM2018(List.of(18), List.of(EV3101, EV3104, EV3105, EV3106, EV4105, EV4106)),
-    FROM2019(List.of(19), List.of(EV3101, EV3106, EV4105, EV4107)),
-    FROM2020(List.of(20, 21), List.of(EV3101, EV3106, EV3111, EV4106, EV4107));
+    FROM2018(List.of(18, 19, 20, 21), List.of(EV3101, EV3106, EV3111, EV4106, EV4107));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;

--- a/src/main/java/com/gist/graduation/requirment/domain/major/MechanicalEngineeringMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/MechanicalEngineeringMajor.java
@@ -12,10 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum MechanicalEngineeringMajor {
 
-    FROM2018(List.of(18), List.of(MC3103, MC3105, MC4101)),
-    FROM2019(List.of(19), List.of(MC2100, MC2100_1, MC2101, MC2101_1, MC3103, MC3105)),
-    FROM2020(List.of(20), List.of(MC2100, MC2100_1, MC2101, MC2101_1, MC2102, MC2102_1, MC2103, MC3212)),
-    FROM2021(List.of(21), List.of(MC2100, MC2100_1, MC2101, MC2101_1, MC2102, MC2102_1, MC2103, MC3106, MC3107));
+    FROM2021(List.of(18,19,20,21), List.of(MC2100, MC2100_1, MC2101, MC2101_1, MC2102, MC2102_1, MC2103, MC3106, MC3107));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;


### PR DESCRIPTION
학사편람에 따른 전공 과목 구분이 모호해 최신 학사편람을 기준으로 변경했습니다.