### PR TITLE
fix: major 처리 기준 수정

### DIFF
--- a/src/main/java/com/gist/graduation/requirment/domain/GraduationRequirementStatus.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/GraduationRequirementStatus.java
@@ -5,6 +5,7 @@ import com.gist.graduation.requirment.domain.humanities.Humanities;
 import com.gist.graduation.requirment.domain.language.LanguageBasic;
 import com.gist.graduation.requirment.domain.major.Major;
 import com.gist.graduation.requirment.domain.major.MajorType;
+import com.gist.graduation.requirment.domain.other.EtcDuplication;
 import com.gist.graduation.requirment.domain.other.OtherUncheckedClass;
 import com.gist.graduation.requirment.domain.science.ScienceBasic;
 import com.gist.graduation.user.taken_course.TakenCourse;
@@ -42,6 +43,7 @@ public class GraduationRequirementStatus {
     }
 
     public void checkGraduationRequirements(Integer studentId, UserTakenCoursesList userTakenCoursesList, MajorType majorType) {
+        EtcDuplication.checkDuplicate(userTakenCoursesList);
         setTotalCredits(userTakenCoursesList);
         isSatisfied();
 

--- a/src/main/java/com/gist/graduation/requirment/domain/constants/MajorMandatoryConstants.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/constants/MajorMandatoryConstants.java
@@ -31,10 +31,11 @@ public class MajorMandatoryConstants {
         public static final TakenCourse CH2103 = new TakenCourse("유기화학Ⅰ", "CH2103", "3");
         public static final TakenCourse CH2104 = new TakenCourse("물리화학 B", "CH2104", "3");
         public static final TakenCourse CH2105 = new TakenCourse("화학합성실험", "CH2105", "3");
-        public static final TakenCourse CH3102 = new TakenCourse("화학합성실험", "CH3102", "3");
-        public static final TakenCourse CH3103 = new TakenCourse("고급화학실험", "CH3103", "3");
+        public static final TakenCourse GS2202 = new TakenCourse("물리화학 Ⅰ", "GS2202", "3");
+        //        public static final TakenCourse CH3102 = new TakenCourse("화학합성실험", "CH3102", "3"); 2018년 1학기까지 존재
+//        public static final TakenCourse CH3103 = new TakenCourse("고급화학실험", "CH3103", "3"); 18학사편람에 필수 과목임
         public static final TakenCourse CH3104 = new TakenCourse("물리화학 II", "CH3104", "3");
-        public static final TakenCourse CH3105 = new TakenCourse("유기화학 II", "CH3105", "3");
+        //        public static final TakenCourse CH3105 = new TakenCourse("유기화학 II", "CH3105", "3"); // 18학사편람에 필수 과목임
         public static final TakenCourse CH3106 = new TakenCourse("생화학 Ⅰ", "CH3106", "3");
         public static final TakenCourse CH3107 = new TakenCourse("무기화학", "CH3107", "3");
     }
@@ -68,13 +69,13 @@ public class MajorMandatoryConstants {
         public static final String BS = "BS";
         public static final TakenCourse BS2101 = new TakenCourse("유기화학 Ⅰ", "BS2101", "3");
         public static final TakenCourse BS2102 = new TakenCourse("분자생물학", "BS2102", "3");
-        public static final TakenCourse BS2103 = new TakenCourse("생화학·분자생물학 실험", "BS2103", "3");
-        public static final TakenCourse BS2104 = new TakenCourse("생화학 I", "BS2104", "3");
+        public static final TakenCourse BS2104 = new TakenCourse("생화학 I", "BS3113", "3");  // 2019까지 과목코드
+        public static final TakenCourse BS2104_1 = new TakenCourse("생화학 I", "BS2104", "3");
         public static final TakenCourse BS3101 = new TakenCourse("생화학 II", "BS3101", "3");
         public static final TakenCourse BS3105 = new TakenCourse("세포생물학", "BS3105", "3");
-        public static final TakenCourse BS3111 = new TakenCourse("생화학·분자생물학 실험", "BS3111", "3");
+        public static final TakenCourse BS2103 = new TakenCourse("생화학·분자생물학 실험", "BS3111", "3"); // 2019까지 과목코드
+        public static final TakenCourse BS2103_1 = new TakenCourse("생화학·분자생물학 실험", "BS2103", "3");
         public static final TakenCourse BS3112 = new TakenCourse("세포·발생생물학 실험", "BS3112", "3");
-        public static final TakenCourse BS3113 = new TakenCourse("생화학 I", "BS3113", "3");
     }
 
     public static class MechanicalEngineering {

--- a/src/main/java/com/gist/graduation/requirment/domain/major/BiologyMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/BiologyMajor.java
@@ -12,9 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum BiologyMajor {
 
-    FROM2018(List.of(18), List.of(BS3101, BS3105, BS3111, BS3112, BS3113)),
-    FROM2019(List.of(19, 20), List.of(BS2101, BS2102, BS3101, BS3105, BS3111, BS3112, BS3113)),
-    FROM2021(List.of(21), List.of(BS2101, BS2102, BS2103, BS2104, BS3101, BS3105, BS3112));
+    FROM2021(List.of(18, 19, 20, 21, 22), List.of(BS2101, BS2102, BS2103, BS2103_1, BS2104, BS2104_1, BS3101, BS3105, BS3112));
 
 
     private final List<Integer> studentId;
@@ -53,10 +51,31 @@ public enum BiologyMajor {
                 .filter(inputUserTakenCourseList::notExist)
                 .collect(Collectors.toList());
 
+        removeDuplication(lackOfMandatoryCourses);
+
         for (TakenCourse lackOfMandatoryCourse : lackOfMandatoryCourses) {
             major.addMessage(String.format("%s를 수강해야 합니다.", lackOfMandatoryCourse.toString()));
         }
     }
+
+    private static void removeDuplication(List<TakenCourse> lackOfMandatoryCourses) {
+        List<TakenCourse> bioChemistry = List.of(BS2104, BS2104_1);
+        List<TakenCourse> bioExperiment = List.of(BS2103, BS2103_1);
+
+        removeEachDuplicate(lackOfMandatoryCourses, bioChemistry, BS2104);
+        removeEachDuplicate(lackOfMandatoryCourses, bioExperiment, BS2103);
+    }
+
+    private static void removeEachDuplicate(List<TakenCourse> userTakenMandatoryCourses, List<TakenCourse> duplicatedNameCourse, TakenCourse oldCourse) {
+        if (userTakenMandatoryCourses.stream().anyMatch(duplicatedNameCourse::contains)) {
+            if (userTakenMandatoryCourses.containsAll(duplicatedNameCourse)) {
+                userTakenMandatoryCourses.remove(oldCourse);
+                return;
+            }
+            userTakenMandatoryCourses.removeAll(duplicatedNameCourse);
+        }
+    }
+
 
     private static void checkElectiveCourses(UserTakenCoursesList inputUserTakenCourseList, Major major, BiologyMajor biologyMajor) {
         List<TakenCourse> mandatoryCourses = biologyMajor.mandatoryCourses;

--- a/src/main/java/com/gist/graduation/requirment/domain/major/ChemistryMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/ChemistryMajor.java
@@ -12,8 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum ChemistryMajor {
 
-    FROM2018(List.of(18), List.of(CH3102, CH3103, CH3104, CH3105, CH3106)),
-    FROM2019(List.of(19, 20, 21), List.of(CH2101, CH2102, CH2103, CH2104, CH2105, CH3106, CH3107));
+    FROM2018(List.of(18, 19, 20, 21, 22), List.of(CH2101, CH2102, CH2103, CH2104, CH2105, CH3106, CH3107));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;
@@ -46,8 +45,12 @@ public enum ChemistryMajor {
 
     private static void checkException(List<TakenCourse> userTakenMandatoryCourses) {
         List<TakenCourse> physicalChemistryA = List.of(CH2102, CH3104);
+        List<TakenCourse> physicalChemistryB = List.of(GS2202, CH2104);
         if (userTakenMandatoryCourses.containsAll(physicalChemistryA)) {
             userTakenMandatoryCourses.remove(CH3104);
+        }
+        if (userTakenMandatoryCourses.containsAll(physicalChemistryB)) {
+            userTakenMandatoryCourses.remove(CH2102);
         }
     }
 

--- a/src/main/java/com/gist/graduation/requirment/domain/major/EnvironmentMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/EnvironmentMajor.java
@@ -12,7 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum EnvironmentMajor {
 
-    FROM2018(List.of(18, 19, 20, 21), List.of(EV3101, EV3106, EV3111, EV4106, EV4107));
+    FROM2018(List.of(18, 19, 20, 21, 22), List.of(EV3101, EV3106, EV3111, EV4106, EV4107));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;

--- a/src/main/java/com/gist/graduation/requirment/domain/major/MaterialScienceMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/MaterialScienceMajor.java
@@ -12,8 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum MaterialScienceMajor {
 
-    FROM2018(List.of(18), List.of(MA3101, MA3102, MA3104, MA3105)),
-    FROM2019(List.of(19, 20, 21), List.of(MA2101, MA2102, MA2103, MA2104, MA3104, MA3105));
+    FROM2018(List.of(18, 19, 20, 21, 22), List.of(MA2101, MA2102, MA2103, MA2104, MA3104, MA3105));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;

--- a/src/main/java/com/gist/graduation/requirment/domain/major/MechanicalEngineeringMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/MechanicalEngineeringMajor.java
@@ -57,19 +57,23 @@ public enum MechanicalEngineeringMajor {
         }
     }
 
-    private static void removeDuplication(List<TakenCourse> userTakenMandatoryCourses) {
+    private static void removeDuplication(List<TakenCourse> lackOfMandatoryClass) {
         List<TakenCourse> thermodynamics = List.of(MC2100, MC2100_1);
         List<TakenCourse> solidMechanics = List.of(MC2101, MC2101_1);
         List<TakenCourse> fluidMechanics = List.of(MC2102, MC2102_1);
 
-        if (userTakenMandatoryCourses.containsAll(thermodynamics)) {
-            userTakenMandatoryCourses.remove(MC2100);
-        }
-        if (userTakenMandatoryCourses.containsAll(solidMechanics)) {
-            userTakenMandatoryCourses.remove(MC2101);
-        }
-        if (userTakenMandatoryCourses.containsAll(fluidMechanics)) {
-            userTakenMandatoryCourses.remove(MC2102);
+        removeDuplicate(lackOfMandatoryClass, thermodynamics, MC2100);
+        removeDuplicate(lackOfMandatoryClass, solidMechanics, MC2101);
+        removeDuplicate(lackOfMandatoryClass, fluidMechanics, MC2102);
+    }
+
+    private static void removeDuplicate(List<TakenCourse> userTakenMandatoryCourses, List<TakenCourse> duplicatedNameCourse, TakenCourse oldCourse) {
+        if (userTakenMandatoryCourses.stream().anyMatch(duplicatedNameCourse::contains)) {
+            if (userTakenMandatoryCourses.containsAll(duplicatedNameCourse)) {
+                userTakenMandatoryCourses.remove(oldCourse);
+                return;
+            }
+            userTakenMandatoryCourses.removeAll(duplicatedNameCourse);
         }
     }
 

--- a/src/main/java/com/gist/graduation/requirment/domain/major/MechanicalEngineeringMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/MechanicalEngineeringMajor.java
@@ -12,7 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum MechanicalEngineeringMajor {
 
-    FROM2021(List.of(18,19,20,21), List.of(MC2100, MC2100_1, MC2101, MC2101_1, MC2102, MC2102_1, MC2103, MC3106, MC3107));
+    FROM2018(List.of(18, 19, 20, 21, 22), List.of(MC2100, MC2100_1, MC2101, MC2101_1, MC2102, MC2102_1, MC2103, MC3106, MC3107));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;

--- a/src/main/java/com/gist/graduation/requirment/domain/major/PhysicsMajor.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/major/PhysicsMajor.java
@@ -12,9 +12,7 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 @RequiredArgsConstructor
 public enum PhysicsMajor {
 
-    FROM2018(List.of(18), List.of(PS3101, PS3103, PS3104, PS3105, PS3106, PS3107)),
-    FROM2019(List.of(19, 20), List.of(PS2101, PS2102, PS3103, PS3104, PS3105, PS3106, PS3107)),
-    FROM2021(List.of(21), List.of(PS2101, PS2102, PS2103, PS3103, PS3104, PS3105, PS3106, PS3107));
+    FROM2018(List.of(18, 19, 20, 21, 22), List.of(PS2101, PS2102, PS2103, PS3103, PS3104, PS3105, PS3106, PS3107));
 
     private final List<Integer> studentId;
     private final List<TakenCourse> mandatoryCourses;

--- a/src/main/java/com/gist/graduation/requirment/domain/other/EtcDuplication.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/other/EtcDuplication.java
@@ -3,11 +3,28 @@ package com.gist.graduation.requirment.domain.other;
 import com.gist.graduation.user.taken_course.TakenCourse;
 import com.gist.graduation.user.taken_course.UserTakenCoursesList;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class EtcDuplication {
 
     public static final TakenCourse SOCIAL_VOLUNTEER = new TakenCourse("사회봉사", "UC0201", "1");
     public static final TakenCourse OVER_SEAS_VOLUNTEER = new TakenCourse("해외봉사", "UC0203", "1");
     public static final TakenCourse CREATIVITY = new TakenCourse("창의함양", "UC0202", "1");
+
+    public static void checkDuplicate(UserTakenCoursesList inputUserTakenCoursesList) {
+        if (inputUserTakenCoursesList.getTakenCourses().containsAll(List.of(SOCIAL_VOLUNTEER, OVER_SEAS_VOLUNTEER))) {
+            inputUserTakenCoursesList.getTakenCourses().remove(SOCIAL_VOLUNTEER);
+        }
+
+        List<TakenCourse> creativityCourses = inputUserTakenCoursesList.getTakenCourses().stream().filter(s -> s.equals(CREATIVITY)).collect(Collectors.toList());
+        if (creativityCourses.size() > 1) {
+            inputUserTakenCoursesList.getTakenCourses().removeAll(creativityCourses);
+            inputUserTakenCoursesList.getTakenCourses().add(creativityCourses.get(0));
+        }
+    }
+
+
 
 
 

--- a/src/main/java/com/gist/graduation/requirment/domain/other/EtcDuplication.java
+++ b/src/main/java/com/gist/graduation/requirment/domain/other/EtcDuplication.java
@@ -1,0 +1,14 @@
+package com.gist.graduation.requirment.domain.other;
+
+import com.gist.graduation.user.taken_course.TakenCourse;
+import com.gist.graduation.user.taken_course.UserTakenCoursesList;
+
+public class EtcDuplication {
+
+    public static final TakenCourse SOCIAL_VOLUNTEER = new TakenCourse("사회봉사", "UC0201", "1");
+    public static final TakenCourse OVER_SEAS_VOLUNTEER = new TakenCourse("해외봉사", "UC0203", "1");
+    public static final TakenCourse CREATIVITY = new TakenCourse("창의함양", "UC0202", "1");
+
+
+
+}

--- a/src/test/java/com/gist/graduation/printer/CourseListPrinterTest.java
+++ b/src/test/java/com/gist/graduation/printer/CourseListPrinterTest.java
@@ -1,11 +1,11 @@
-package com.gist.graduation.utils;
+package com.gist.graduation.printer;
 
-import com.gist.graduation.printer.TestCourseListPrinter;
+import com.gist.graduation.utils.CourseListParser;
+import com.gist.graduation.utils.RegisteredCourse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class CourseListPrinterTest {
 
@@ -57,6 +57,7 @@ public class CourseListPrinterTest {
     @Test
     void softwareBasicPrinter() {
         testCourseListPrinter.printClassByCreditAndName(courseList, "소프트웨어", 2);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "물리화학", 3);
     }
 
 }

--- a/src/test/java/com/gist/graduation/printer/EtcPrinter.java
+++ b/src/test/java/com/gist/graduation/printer/EtcPrinter.java
@@ -1,6 +1,5 @@
 package com.gist.graduation.printer;
 
-import com.gist.graduation.utils.CourseListPrinterTest;
 import org.junit.jupiter.api.Test;
 
 public class EtcPrinter extends CourseListPrinterTest {

--- a/src/test/java/com/gist/graduation/printer/EtcPrinter.java
+++ b/src/test/java/com/gist/graduation/printer/EtcPrinter.java
@@ -1,0 +1,45 @@
+package com.gist.graduation.printer;
+
+import com.gist.graduation.utils.CourseListPrinterTest;
+import org.junit.jupiter.api.Test;
+
+public class EtcPrinter extends CourseListPrinterTest {
+
+    @Test
+    void colloquiumTest() {
+        String name = "콜로퀴움";
+        testCourseListPrinter.printClassByCreditAndName(courseList, name, 0);
+    }
+
+    @Test
+    void researchTest() {
+        String name = "연구";
+        testCourseListPrinter.printByCode(courseList, "910");
+    }
+
+    @Test
+    void artAndSportTest() {
+        String artCode = "GS02";
+        String sportCode = "GS01";
+        testCourseListPrinter.printByCode(courseList, artCode);
+        testCourseListPrinter.printByCode(courseList, sportCode);
+    }
+
+    @Test
+    void freshmanMandatoryTest() {
+        String freshMan = "새내기";
+        String findMajorCourse = "전공탐색";
+        testCourseListPrinter.printClassByCreditAndName(courseList, freshMan, 1);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "세미나", 1);
+        testCourseListPrinter.printClassByCreditAndName(courseList, findMajorCourse, 1);
+    }
+
+    @Test
+    void printVolunteerAndCreativeCulture() {
+        String volunteer = "봉사";
+        String creativity = "창의";
+        testCourseListPrinter.printClassByCreditAndName(courseList, volunteer, 1);
+        testCourseListPrinter.printClassByCreditAndName(courseList, creativity, 1);
+    }
+
+}

--- a/src/test/java/com/gist/graduation/printer/HumanitiesPrinter.java
+++ b/src/test/java/com/gist/graduation/printer/HumanitiesPrinter.java
@@ -1,7 +1,6 @@
 package com.gist.graduation.printer;
 
 import com.gist.graduation.utils.CourseListParser;
-import com.gist.graduation.utils.CourseListPrinterTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;

--- a/src/test/java/com/gist/graduation/printer/HumanitiesPrinter.java
+++ b/src/test/java/com/gist/graduation/printer/HumanitiesPrinter.java
@@ -1,0 +1,37 @@
+package com.gist.graduation.printer;
+
+import com.gist.graduation.utils.CourseListParser;
+import com.gist.graduation.utils.CourseListPrinterTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HumanitiesPrinter extends CourseListPrinterTest {
+
+    @Test
+    void humanitiesTest() {
+        testCourseListPrinter.printTakenCourseCollectionPretty(CourseListParser.getHumanitiesCoursesList()
+                .stream()
+                .sorted((a, b) -> a.getCourseCode().compareTo(b.getCourseCode()))
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    void humanitiesWithoutGSCTest() {
+        testCourseListPrinter.printTakenCourseCollectionPretty(CourseListParser.getHumanitiesWithoutGSC()
+                .stream()
+                .sorted((a, b) -> a.getCourseCode().compareTo(b.getCourseCode()))
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    void GSCTest() {
+        List<String> gscCode = List.of("GS25", "GS26", "GS27", "GS28", "GS29", "GS35");
+        testCourseListPrinter.printTakenCourseCollectionPretty(CourseListParser.getHumanitiesCoursesList()
+                .stream()
+                .filter(s -> gscCode.stream().anyMatch(t -> s.getCourseCode().contains(t)))
+                .sorted((a, b) -> a.getCourseCode().compareTo(b.getCourseCode()))
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/test/java/com/gist/graduation/printer/TestCourseListPrinter.java
+++ b/src/test/java/com/gist/graduation/printer/TestCourseListPrinter.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class CourseListPrinter {
+public class TestCourseListPrinter {
 
     public void printCoreEnglishCourses(List<RegisteredCourse> registeredCourseList) {
         Set<RegisteredCourse> englishConditionCourse = registeredCourseList.stream()

--- a/src/test/java/com/gist/graduation/requirment/domain/major/BiologyMajorTest.java
+++ b/src/test/java/com/gist/graduation/requirment/domain/major/BiologyMajorTest.java
@@ -1,0 +1,9 @@
+package com.gist.graduation.requirment.domain.major;
+
+class BiologyMajorTest {
+
+//    @Test
+//    void checkverified() {
+//        BiologyMajor.checkverified();
+//    }
+}

--- a/src/test/java/com/gist/graduation/requirment/domain/major/MajorMandatoryTest.java
+++ b/src/test/java/com/gist/graduation/requirment/domain/major/MajorMandatoryTest.java
@@ -1,0 +1,85 @@
+package com.gist.graduation.requirment.domain.major;
+
+import com.gist.graduation.user.taken_course.TakenCourse;
+import com.gist.graduation.user.taken_course.UserTakenCoursesList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static com.gist.graduation.requirment.domain.constants.MajorMandatoryConstants.Biology.*;
+import static com.gist.graduation.requirment.domain.constants.MajorMandatoryConstants.Chemistry.*;
+import static com.gist.graduation.requirment.domain.constants.MajorMandatoryConstants.MechanicalEngineering.*;
+
+class MajorMandatoryTest {
+
+    private UserTakenCoursesList userTakenCoursesList;
+
+    @BeforeEach
+    void setup() {
+        userTakenCoursesList = new UserTakenCoursesList();
+    }
+
+    private static Stream<List<TakenCourse>> mechanicalMajorArguments() {
+        List<List<TakenCourse>> arguments = new ArrayList<>();
+        arguments.add(List.of(MC2100, MC2101, MC2103, MC3106, MC3107));
+        arguments.add(List.of(MC2100, MC3106, MC3107));
+        arguments.add(List.of(MC2100, MC2101, MC2102_1, MC2103, MC3106, MC3107));
+        arguments.add(List.of(MC2100_1, MC2101_1, MC2102_1, MC2103, MC3106, MC3107));
+        arguments.add(List.of());
+        return arguments.stream();
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("mechanicalMajorArguments")
+    void checkMechanicalMandatory(List<TakenCourse> majorCourseLists) {
+        Major major = new Major();
+        userTakenCoursesList.addAll(majorCourseLists);
+        major.checkRequirementByStudentId(20, userTakenCoursesList, MajorType.MC);
+        System.out.println(major);
+    }
+
+    private static Stream<List<TakenCourse>> biologyMajorArguments() {
+        List<List<TakenCourse>> arguments = new ArrayList<>();
+        arguments.add(List.of(BS2101, BS2102, BS2103, BS2104));
+        arguments.add(List.of(BS2101, BS2102, BS2103, BS2104, BS3101, BS3105, BS3112));
+        arguments.add(List.of(BS2101, BS2102, BS2103_1, BS2104, BS3101, BS3112));
+        arguments.add(List.of());
+        return arguments.stream();
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("biologyMajorArguments")
+    void checkBiologyMandatory(List<TakenCourse> majorCourseLists) {
+        Major major = new Major();
+        userTakenCoursesList.addAll(majorCourseLists);
+        major.checkRequirementByStudentId(20, userTakenCoursesList, MajorType.BS);
+        System.out.println(major);
+    }
+
+    private static Stream<List<TakenCourse>> chemistryMajorArguments() {
+        List<List<TakenCourse>> arguments = new ArrayList<>();
+        arguments.add(List.of(CH2101, CH2102, CH2103, CH2104, CH2105, CH3106, CH3107));
+        arguments.add(List.of(CH2101, CH2102, CH2103, CH2104, CH2105));
+        arguments.add(List.of(CH2101, CH2102, CH2103, CH2105, CH3106, GS2202));
+        arguments.add(List.of(CH2101, CH2102, CH2103, CH2105, CH3106, CH3104));
+        arguments.add(List.of());
+        return arguments.stream();
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("chemistryMajorArguments")
+    void checkChemistryMandatory(List<TakenCourse> majorCourseLists) {
+        Major major = new Major();
+        userTakenCoursesList.addAll(majorCourseLists);
+        major.checkRequirementByStudentId(20, userTakenCoursesList, MajorType.CH);
+        System.out.println(major);
+    }
+
+}

--- a/src/test/java/com/gist/graduation/utils/CourseListPrinterTest.java
+++ b/src/test/java/com/gist/graduation/utils/CourseListPrinterTest.java
@@ -1,119 +1,62 @@
 package com.gist.graduation.utils;
 
-import com.gist.graduation.printer.CourseListPrinter;
+import com.gist.graduation.printer.TestCourseListPrinter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-class CourseListPrinterTest {
+public class CourseListPrinterTest {
 
-    private CourseListPrinter courseListPrinter;
-    private CourseListParser courseListParser;
-    private List<RegisteredCourse> courseList;
+    protected TestCourseListPrinter testCourseListPrinter;
+    protected List<RegisteredCourse> courseList;
 
     @BeforeEach
     void setup() {
-        courseListParser = new CourseListParser();
-        courseListPrinter = new CourseListPrinter();
+        testCourseListPrinter = new TestCourseListPrinter();
         courseList = CourseListParser.getCourseList();
     }
 
     @Test
-    void englishPrinterTest() {
-        courseListPrinter.printCoreEnglishCourses(courseList);
+    public void englishPrinterTest() {
+        testCourseListPrinter.printCoreEnglishCourses(courseList);
     }
 
     @Test
-    void writingPrinterTest() {
-        courseListPrinter.printCoreWritingClass(courseList);
+    private void writingPrinterTest() {
+        testCourseListPrinter.printCoreWritingClass(courseList);
     }
 
     @Test
     void calculusPrinterTest() {
-        courseListPrinter.printCalculusClass(courseList);
+        testCourseListPrinter.printCalculusClass(courseList);
     }
 
     @Test
     void coreMathTest() {
-        courseListPrinter.printClassByCreditAndName(courseList, "다변수", 3);
-        courseListPrinter.printClassByCreditAndName(courseList, "선형대수학", 3);
-        courseListPrinter.printClassByCreditAndName(courseList, " 미분방정식", 3);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "다변수", 3);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "선형대수학", 3);
+        testCourseListPrinter.printClassByCreditAndName(courseList, " 미분방정식", 3);
     }
 
     @Test
     void coreScienceTest() {
-        courseListPrinter.printClassByCreditAndName(courseList, "일반물리학", 3);
-        courseListPrinter.printClassByCreditAndName(courseList, "실험", 1);
-        courseListPrinter.printClassByCreditAndName(courseList, "일반화학", 3);
-        courseListPrinter.printClassByCreditAndNameAndCode(courseList, "생물학", 3, "GS");
-        courseListPrinter.printClassByCreditAndName(courseList, "컴퓨터 프로그래밍", 3);
-    }
-
-    @Test
-    void humanitiesTest() {
-        courseListPrinter.printTakenCourseCollectionPretty(CourseListParser.getHumanitiesCoursesList()
-                .stream()
-                .sorted((a, b) -> a.getCourseCode().compareTo(b.getCourseCode()))
-                .collect(Collectors.toList()));
-    }
-
-    @Test
-    void humanitiesWithoutGSCTest() {
-        courseListPrinter.printTakenCourseCollectionPretty(CourseListParser.getHumanitiesWithoutGSC()
-                .stream()
-                .sorted((a, b) -> a.getCourseCode().compareTo(b.getCourseCode()))
-                .collect(Collectors.toList()));
-    }
-
-    @Test
-    void GSCTest() {
-        List<String> gscCode = List.of("GS25", "GS26", "GS27", "GS28", "GS29", "GS35");
-        courseListPrinter.printTakenCourseCollectionPretty(CourseListParser.getHumanitiesCoursesList()
-                .stream()
-                .filter(s -> gscCode.stream().anyMatch(t -> s.getCourseCode().contains(t)))
-                .sorted((a, b) -> a.getCourseCode().compareTo(b.getCourseCode()))
-                .collect(Collectors.toList()));
-    }
-
-    @Test
-    void ETCTest() {
-        String artCode = "GS02";
-        String sportCode = "GS01";
-        courseListPrinter.printByCode(courseList, artCode);
-        courseListPrinter.printByCode(courseList, sportCode);
-    }
-
-    @Test
-    void colloquiumTest() {
-        String name = "콜로퀴움";
-        courseListPrinter.printClassByCreditAndName(courseList, name, 0);
-    }
-
-    @Test
-    void researchTest() {
-        String name = "연구";
-        courseListPrinter.printByCode(courseList, "910");
-    }
-
-    @Test
-    void freshmanMandatoryTest() {
-        String freshMan = "새내기";
-        String findMajorCourse = "전공탐색";
-        courseListPrinter.printClassByCreditAndName(courseList, freshMan, 1);
-        courseListPrinter.printClassByCreditAndName(courseList, "세미나", 1);
-        courseListPrinter.printClassByCreditAndName(courseList, findMajorCourse, 1);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "일반물리학", 3);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "실험", 1);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "일반화학", 3);
+        testCourseListPrinter.printClassByCreditAndNameAndCode(courseList, "생물학", 3, "GS");
+        testCourseListPrinter.printClassByCreditAndName(courseList, "컴퓨터 프로그래밍", 3);
     }
 
     @Test
     void mathPrinter() {
-        courseListPrinter.printClassByCreditAndName(courseList, "미분", 3);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "미분", 3);
     }
 
     @Test
     void softwareBasicPrinter() {
-        courseListPrinter.printClassByCreditAndName(courseList, "소프트웨어", 2);
+        testCourseListPrinter.printClassByCreditAndName(courseList, "소프트웨어", 2);
     }
 
 }

--- a/src/test/java/com/gist/graduation/utils/MajorCoursesListPrinterTest.java
+++ b/src/test/java/com/gist/graduation/utils/MajorCoursesListPrinterTest.java
@@ -1,6 +1,6 @@
 package com.gist.graduation.utils;
 
-import com.gist.graduation.printer.CourseListPrinter;
+import com.gist.graduation.printer.TestCourseListPrinter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,39 +14,39 @@ import static com.gist.graduation.requirment.domain.constants.MajorMandatoryCons
 
 public class MajorCoursesListPrinterTest {
 
-    private CourseListPrinter courseListPrinter;
+    private TestCourseListPrinter testCourseListPrinter;
     private CourseListParser courseListParser;
     private List<RegisteredCourse> courseList;
 
     @BeforeEach
     void setup() throws IOException {
         courseListParser = new CourseListParser();
-        courseListPrinter = new CourseListPrinter();
+        testCourseListPrinter = new TestCourseListPrinter();
         courseList = CourseListParser.getCourseList();
     }
 
     @Test
     void physicsPrintTest() {
-        courseListPrinter.printByCode(courseList, "PS");
+        testCourseListPrinter.printByCode(courseList, "PS");
     }
 
     @Test
     void ChemistryPrintTest() {
-        courseListPrinter.printByCode(courseList, CH);
+        testCourseListPrinter.printByCode(courseList, CH);
     }
 
     @Test
     void EnvironmentPrintTest() {
-        courseListPrinter.printMandatoryMajorClass(courseList, EV);
+        testCourseListPrinter.printMandatoryMajorClass(courseList, EV);
     }
 
     @Test
     void materialSciencePrintTest() {
-        courseListPrinter.printMandatoryMajorClass(courseList, MA);
+        testCourseListPrinter.printMandatoryMajorClass(courseList, MA);
     }
 
     @Test
     void mechanicalEngineeringPrintTest() {
-        courseListPrinter.printMandatoryMajorClass(courseList, MC);
+        testCourseListPrinter.printMandatoryMajorClass(courseList, MC);
     }
 }


### PR DESCRIPTION
학적팀 미팅을 통해 전공 과목이 최신 학사편람을 기준으로 만들어짐을 확답을 받아 기준을 이와 같이 수정했습니다. 추후 지속적으로 내부로직을 변경해야합니다. 뿐만 아니라, 사회봉사, 무한도전 같은 중복 불허 과목 처리도 진행했습니다.